### PR TITLE
LPS-120550: Hide Relaunch, Summary menu item for backGroundTask upgraded from 6.2

### DIFF
--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/process_list_menu/init.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/process_list_menu/init.jsp
@@ -18,10 +18,20 @@
 
 <%
 BackgroundTask backgroundTask = (BackgroundTask)request.getAttribute("liferay-staging:process-list-menu:backgroundTask");
+
 boolean deleteMenu = GetterUtil.getBoolean(request.getAttribute("liferay-staging:process-list-menu:deleteMenu"));
 boolean localPublishing = GetterUtil.getBoolean(request.getAttribute("liferay-staging:process-list-menu:localPublishing"));
 boolean relaunchMenu = GetterUtil.getBoolean(request.getAttribute("liferay-staging:process-list-menu:relaunchMenu"));
 boolean summaryMenu = GetterUtil.getBoolean(request.getAttribute("liferay-staging:process-list-menu:summaryMenu"));
+
+Map<String, Serializable> contextMap = backgroundTask.getTaskContextMap();
+
+long exportImportConfigurationId = GetterUtil.getLong(String.valueOf(contextMap.get("exportImportConfigurationId")));
+
+if (exportImportConfigurationId == 0) {
+	relaunchMenu = false;
+	summaryMenu = false;
+}
 
 Date completionDate = backgroundTask.getCompletionDate();
 

--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/process_list_menu/items/summary.jspf
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/process_list_menu/items/summary.jspf
@@ -17,10 +17,6 @@
 <%
 String processCmd = null;
 
-Map<String, Serializable> contextMap = backgroundTask.getTaskContextMap();
-
-long exportImportConfigurationId = MapUtil.getLong(contextMap, "exportImportConfigurationId");
-
 if (exportImportConfigurationId > 0) {
 	ExportImportConfiguration exportImportConfiguration = ExportImportConfigurationLocalServiceUtil.getExportImportConfiguration(exportImportConfigurationId);
 


### PR DESCRIPTION
Hi @haubuicodeengine 
I update my works for the ticket https://issues.liferay.com/browse/LPS-120550
I found the fix from the ticket [LPS-92517](https://issues.liferay.com/browse/LPS-92517). But they do have exceptions in some places: 
- https://github.com/liferay/liferay-portal-ee/blob/master/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/process_summary/init.jsp#L36-L44
- https://github.com/liferay/liferay-portal-ee/blob/master/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/EditPublishConfigurationMVCActionCommand.java#L175-L191
So, I think we can hide the actions menu to resolve it.
Please help me review and give me some feedback. Thanks